### PR TITLE
Add logic to properly check for garage state. 

### DIFF
--- a/athom-garage-door.yaml
+++ b/athom-garage-door.yaml
@@ -99,11 +99,21 @@ cover:
     name: "${friendly_name}"
     lambda: "return id(contact).state ? COVER_OPEN : COVER_CLOSED;"
     open_action:
-      - switch.turn_on: relay
+      then:
+        - if:
+            condition:
+              lambda: 'return id(contact).state == false;'
+            then:
+              - switch.turn_on: relay
     stop_action:
       - switch.turn_on: relay
     close_action:
-      - switch.turn_on: relay
+      then:
+        - if:
+            condition:
+              lambda: 'return id(contact).state == true;'
+            then:
+              - switch.turn_on: relay
 
 text_sensor:
   - platform: wifi_info

--- a/athom-garage-door.yaml
+++ b/athom-garage-door.yaml
@@ -2,7 +2,7 @@ substitutions:
   name: "athom-garage-door"
   friendly_name: "Athom Garage Door"
   project_name: "athom.garage-door"
-  project_version: "1.0"
+  project_version: "1.1"
 
 esphome:
   name: "${name}"

--- a/athom-garage-door.yaml
+++ b/athom-garage-door.yaml
@@ -102,7 +102,7 @@ cover:
       then:
         - if:
             condition:
-              lambda: 'return id(contact).state == false;'
+              lambda: 'return !id(contact).state;'
             then:
               - switch.turn_on: relay
     stop_action:
@@ -111,7 +111,7 @@ cover:
       then:
         - if:
             condition:
-              lambda: 'return id(contact).state == true;'
+              lambda: 'return id(contact).state;'
             then:
               - switch.turn_on: relay
 


### PR DESCRIPTION
This pull request configures the garage door so that its controls are actually stateful when working with home assistant. 

Previously if you called cover.close on this device and the garage was closed, it would open the garage.  Which is unwanted and breaks automations that call cover.close to verify state. 

This checks to see if the state is in a condition that needs an action and triggers the relay only if needed. 